### PR TITLE
fix: Correct typo in useVideos hook

### DIFF
--- a/src/hooks/useVideos.ts
+++ b/src/hooks/useVideos.ts
@@ -8,7 +8,7 @@ export const useVideos = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {.
+  useEffect(() => {
     const fetchAllVideos = async () => {
       try {
         setLoading(true);


### PR DESCRIPTION
This commit fixes a syntax error in the `useEffect` of the `useVideos` hook, which was causing the build to fail.