### PR TITLE
fix: Correctly extract channelId from YouTube API response

### DIFF
--- a/src/services/youtube.ts
+++ b/src/services/youtube.ts
@@ -57,7 +57,7 @@ class YouTubeService {
       if (!channelSearch.items || channelSearch.items.length === 0) {
         throw new Error(`Could not find channel: ${channelName}`);
       }
-      const channelId = channelSearch.items[0].id.videoId; // Note: for channels, the search result gives videoId field for channelId
+      const channelId = channelSearch.items[0].id.channelId;
 
       // Step 2: Use the found channelId to get the latest videos
       const videoSearch = await this.makeRequest<YouTubeSearchResponse>('/search', {


### PR DESCRIPTION
This commit fixes a bug where the code was attempting to use `videoId` instead of `channelId` when searching for a channel by name. This was causing an 'Invalid argument' error from the YouTube API.

The code now correctly uses the `channelId` property from the channel search result.