### PR TITLE
fix: Correct YouTube API type definitions

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,7 +8,9 @@
  */
 export interface YouTubeVideo {
   id: {
-    videoId: string;
+    kind: string;
+    videoId?: string;
+    channelId?: string;
   };
   snippet: {
     title:string;


### PR DESCRIPTION
This commit fixes a TypeScript error that occurred because the type definition for a YouTube search result was not flexible enough to handle both video and channel search results.

The `YouTubeVideo` type has been updated to include optional `videoId` and `channelId` properties, which resolves the build error.